### PR TITLE
Fixes commit 35bf55d

### DIFF
--- a/js/MangaElt.js
+++ b/js/MangaElt.js
@@ -110,19 +110,19 @@ function MangaElt(obj) {
 
     //This happens when incoming updates comes from sync
     //if obj.display, obj.read, obj.cats, MAJ this....
-    if (!obj.display) {
+    if (obj.display) {
       this.display = obj.display;
     }
-    if (!obj.read) {
+    if (obj.read) {
       this.read = obj.read;
     }
-    if (!obj.update) {
+    if (obj.update) {
       this.update = obj.update;
     }
     if (obj.cats !== undefined && obj.cats !== null) {
         this.cats = JSON.parse(obj.cats) || obj.cats || [];
     }
-    if (!obj.ts && fromSite) {
+    if (obj.ts && fromSite) {
       this.ts = obj.ts;
     }
   };


### PR DESCRIPTION
This fixes a bug causing that when reading any manga it was set as read (blue background) like if it was the latest chapter, and having to restart the extension to set it again as unread.

It may fix other bugs.

Previously it was "If the object is not null then..."

And after that commit it was "If the object is null then..."
