### PR TITLE
Update MangaElt.js

### DIFF
--- a/js/MangaElt.js
+++ b/js/MangaElt.js
@@ -125,7 +125,11 @@ function MangaElt(obj) {
       this.update = obj.update;
     }
     if (obj.cats !== undefined && obj.cats !== null) {
-        this.cats = JSON.parse(obj.cats) || obj.cats || [];
+        if(obj.cats instanceof Array){
+          this.cats= obj.cats;
+        }else{
+          this.cats = JSON.parse(obj.cats) || [];
+        }
     }
     if (obj.ts && fromSite) {
       this.ts = obj.ts;


### PR DESCRIPTION
This should fix merges https://github.com/AllMangasReader-dev/AMR/issues/111
Trying to parse an array, that is already been parsed and instatntiated as an array is gonna blow up.

Test case:

```{\"mirror\":\"Manga-Fox\",\"name\":\"1/2 Prince\",\"url\":\"http://mangafox.me/manga/1_2_prince/\",\"lastChapterReadURL\":\"http://mangafox.me/manga/1_2_prince/v14/c069/\",\"lastChapterReadName\":\"1/2 Prince 69\",\"read\":0,\"update\":1,\"ts\":1407828322,\"display\":0,\"cats\":\"[]\"},```