### PR TITLE
Update manifest to support github

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -76,7 +76,7 @@
       ]
     }
   ],
-  "content_security_policy" : "script-src 'self' https://ssl.google-analytics.com https://ssl10.ovh.net https://www.google.com/ https://platform.twitter.com/ https://www.facebook.com/ https://raw.github.com/ ; object-src 'self'",
+  "content_security_policy" : "script-src 'self' https://ssl.google-analytics.com https://ssl10.ovh.net https://www.google.com/ https://platform.twitter.com/ https://www.facebook.com/ https://raw.github.com/ https://raw.githubusercontent.com/ ; object-src 'self'",
   "homepage_url" : "http://www.allmangasreader.com/",
   "key" : "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDFE73kwUiPfxcBtTkkkboktSCXCrDxMWvYSO72IabK3Q9pqvkEcViyFcuj6mpztx55kYhwFT+ntasZZiNgzhxkjc9zEuHopyrg+/S2tgGa7ueZ+P8s3IMOeEWj9Mqw2qyvPoZ508Q6FwrGjU6rZAhBtS5dzhibkFxRQc9Yej2ppQIDAQAB",
   "minimum_chrome_version" : "30.0",


### PR DESCRIPTION
Added https://raw.githubusercontent.com/ to the content security policy, since https://raw.github.com/ just redirects, causing security failures.
