### PR TITLE
zoom in and out using - and = on a keybard without numpad

### DIFF
--- a/js/back.js
+++ b/js/back.js
@@ -1426,10 +1426,10 @@ function setKeys() {
       if (e.which == 83) { //S
         window.scrollBy(0, 40);
       }
-      if (e.which == 107) { //+
+      if (e.which == 107 || e.which == 187) { //+
         zoomin();
       }
-      if (e.which == 109) { //-
+      if (e.which == 109 || e.which == 189) { //-
          zoomout();
       }
       if (e.which == 66) { //b


### PR DESCRIPTION
title says it all.

on laptops without numpad, one cannot simply zoom in or zoom out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allmangasreader-dev/amr/137)
<!-- Reviewable:end -->
