### PR TITLE
Fixes never ending loading if onErrorImage

### DIFF
--- a/js/back.js
+++ b/js/back.js
@@ -968,6 +968,7 @@ function onErrorImage() {
       //== loadImage
       $(imgSave).data("urlToLoad", $(this).data("urlToLoad"));
       $(imgSave).css("border", "5px solid white");
+      $(imgSave).addClass("imageAMR");
       $(imgSave).load(onLoadImage);
       $(imgSave).error(onErrorImage);
       getMirrorScript().getImageFromPageAndWrite($(this).data("urlToLoad"), imgSave, document, window.location.href);


### PR DESCRIPTION
Fixes that after a call to the onErrorImage function and the load in
order option is selected it will finish to load the chapter.

In order to trigger this onErrorImage call when a 503 error happens, it's needed a update to the mirrors that give the errors (AllMangasReader-dev/mirrors#29).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/allmangasreader-dev/amr/154)
<!-- Reviewable:end -->
